### PR TITLE
controllermanifest: fetch image from quay org

### DIFF
--- a/manifests/controller.yaml
+++ b/manifests/controller.yaml
@@ -48,4 +48,4 @@ spec:
       containers:
         - name: kubespresso
           command: ['python', '/kubespresso.py']
-          image: quay.io/gbenhaim/kubespresso:1.0.0
+          image: quay.io/kubespresso/kubespresso:1.0.0


### PR DESCRIPTION
* Fetch the image of the controller from `quay.io/kubespresso` org.
* Build trigger was set in quay.io so that any change to the Dockerfile will be built.

https://quay.io/repository/kubespresso/kubespresso