### PR TITLE
Fixed race condition

### DIFF
--- a/kubespresso.py
+++ b/kubespresso.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+from textwrap import dedent
 
 from kubernetes import client, config, watch
 
@@ -73,59 +74,49 @@ def coffee_handler(event):
                     by the `unmarshal_event` method of the `Watch` object.
                     It's defined under `kubernetes.base.watch`.
     """
-    deserves_coffee, explain = should_perform_on(event)
-    if not deserves_coffee:
-        logging.info(Color.colored('yellow', f'Sorry, {explain}'))
+    ok, reason = event_deserves_coffee(event)
+    if not ok:
+        logging.info(Color.colored('yellow', f'Sorry, {reason}'))
         return
-    logging.info(Color.colored('green', f'Good news! {explain}'))
+    ok, reason = annotate_pod(event)
+    if not ok:
+        logging.info(Color.colored('yellow', f'Sorry, {reason}'))
+        return
+    logging.info(Color.colored('green', f'Good news! you\'re getting a coffee'))
     make_coffee()
-    touch_job_event(event)
 
 
-
-def should_perform_on(event) -> (bool, str):
-    """Given an event, decide if we should perform on it or not
-
-    This controller performs on ADDED or MODIFIED event types and only on Job
-    objects.
-
-    :param Event event: Object representing an event. This object is generated
-                        by the `unmarshal_event` method of the `Watch` object.
-                        It's defined under `kubernetes.base.watch`.
+def annotate_pod(event) -> (bool, str):
+    """Annotate the pod under the event
 
     :rtype: tuple(bool, str)
-    :returns: A tuple where the first element is True if we perform on this kind
-              of event and False otherwise. The second element is a string with
-              the reason for the decision.
+    :returns: A tuple that indicates if the pod was annotated succesfully or not
+             and a string representation of the outcome.
     """
+    obj = event['object']
+    patch = generate_annotation_patch(event)
+    obj_meta = obj.metadata
+    patch_applied = apply_patch_on_pod(obj_meta.name, obj_meta.namespace, patch)
+    if patch_applied:
+        return True, 'You definitely deserve a coffee!'
+    return False, 'There is a newer version of the object. Please wait'
+
+
+def event_deserves_coffee(event):
+    obj = event['object']
     if event['type'] not in ('ADDED', 'MODIFIED'):
-        return False, 'coffee is granted only on ADDED or MODIFIED Jobs'
-    if event['raw_object']['kind'] != 'Job':
-        return False, 'coffee is granted only for Job objects'
-    job_expected_duration = int(
+            return False, 'coffee is granted only on ADDED or MODIFIED Pods'
+    if obj.kind != 'Pod':
+        return False, 'coffee is granted only for Pod objects'
+    expected_duration = int(
         extract_field_from_event_annotations(event, EXPECTED_DURATION_LABEL)
         or 0
     )
-    if job_expected_duration < 60:
-        return False, "Job's expected duration is less than 60"
+    if expected_duration < 60:
+        return False, "Pod's expected duration is less than 60"
     if seconds_since_last_modification(event) < 86400:  # 1 day in seconds
         return False, 'you already received a coffee today'
-    return True, 'you definitely deserve a coffee!'
-
-
-def extract_field_from_event_annotations(event, annotation) -> str:
-    """Given a Job event event, return the requested annotation
-
-    We need this method because on some Jobs, `metadata.annotations` might not
-    be set and the default value for annotation is None.
-
-    :rtype: str
-    :returns: The requested annotation or an empty string if it doesn't exist.
-    """
-    annotations = event['object'].metadata.annotations
-    if annotations:
-        return annotations.get(annotation, '')
-    return ''
+    return True, 'you deserve a coffee'
 
 
 def seconds_since_last_modification(event) -> int:
@@ -148,37 +139,101 @@ def make_coffee():
     """Do an API call to the coffee machine and make a coffee
     """
     # ... some coffe machine specific code goes here ....
-    logging.info(Color.colored('cyan', 'Coffe is waiting for you in the kitchen!'))
+    logging.info(Color.colored('cyan', 'Hold on... I\'m boiling the water...'))
+    time.sleep(3)
+    logging.info(Color.colored('cyan', 'Adding sugar...'))
+    time.sleep(2)
+    logging.info(Color.colored('cyan', 'Voila!'))
+    time.sleep(0.2)
+    logging.info(Color.colored(
+        'cyan',
+        """
+               {
+            {   }
+            }_{ __{
+            .-{   }   }-.
+        (   }     {   )
+        |`-.._____..-'|
+        |             ;--.
+        |            (__  \\
+        |             | )  )
+        |             |/  /
+        |             /  /
+        |            (  /
+        \             y'
+         `-.._____..-'
+        """
+    ))
 
 
-def touch_job_event(event):
-    """Set a `last_modified` annotation on a given event
+def generate_annotation_patch(event) -> dict:
+    """Generate `LAST_MODIFIED_LABEL` annotation patch
 
-    In order to keep track of events we already processed, we can set an
-    annotation with a timestamp of the last time we processed this object.
+    In order to keep track of events we already processed, we set an
+    annotation with a timestamp of the last time we processed this object. This
+    method generates a patch object that can be applied via the API.
 
     :param Event event: Object representing an event. This object is generated
                         by the `unmarshal_event` method of the `Watch` object.
                         It's defined under `kubernetes.base.watch`.
+    :rtype: dict
+    :returns: dict with a patch to be applied on the pod.
     """
-    v1_job = event['object']
-    if not v1_job.metadata.annotations:
-            v1_job.metadata.annotations = {}
-    v1_job.metadata.annotations.update({
-        LAST_MODIFIED_LABEL: str(int(time.time()))
-    })
-    obj_name = v1_job.metadata.name
-    ns = v1_job.metadata.namespace
-    batch_api = client.BatchV1Api()
-    batch_api.patch_namespaced_job(obj_name, ns, {'metadata': v1_job.metadata})
-    logging.debug(f'Set {LAST_MODIFIED_LABEL} on {obj_name}')
+    event_object = event['object']
+    resource_version = event_object.metadata.resource_version or '0'
+    now = str(int(time.time()))
+    object_meta = client.V1ObjectMeta(
+        annotations={LAST_MODIFIED_LABEL: now},
+        resource_version=resource_version
+    )
+    # obj_name = event_object.metadata.name
+    # ns = event_object.metadata.namespace
+    return {'metadata': object_meta}
+
+
+def apply_patch_on_pod(object_name:str , namespace: str, patch: object) -> bool:
+    """Safely patch the given `object_name` with the provided object (`body`)
+
+    :rtype: bool
+    :returns: True if the patch was applied successfully and False in case of
+              a conflict.
+    """
+    core_v1_api = client.CoreV1Api()
+    try:
+        core_v1_api.patch_namespaced_pod(object_name, namespace, patch)
+        logging.info(Color.colored(
+            'green', f'Patched {object_name}')
+        )
+        return True
+    except client.rest.ApiException as api_exception:
+        if api_exception.reason == 'Conflict':
+            logging.info(Color.colored(
+                'red', 'There is a newer version of the object')
+            )
+            return False
+        raise
+
+
+def extract_field_from_event_annotations(event, annotation) -> str:
+    """Given an event on `Pod` object, return the requested annotation
+
+    We need this method because on some Pods, `metadata.annotations` might not
+    be set and the default value for annotation is None.
+
+    :rtype: str
+    :returns: The requested annotation or an empty string if it doesn't exist.
+    """
+    annotations = event['object'].metadata.annotations
+    if annotations:
+        return annotations.get(annotation, '')
+    return ''
 
 
 def main():
     setup_logger(logging.INFO)
     cluster_login()
-    batch_api = client.BatchV1Api()
-    stream = watch.Watch().stream(batch_api.list_job_for_all_namespaces)
+    core_v1_api = client.CoreV1Api()
+    stream = watch.Watch().stream(core_v1_api.list_pod_for_all_namespaces)
     event_handlers = [logger_handler, coffee_handler]
     while True:  # In case a timeout will occur during stream processing
         process_stream(stream, event_handlers)


### PR DESCRIPTION
There was a race where several status updates entered
the stream before our controller had a chance to process
and annotate it. The fix is to add a `resourceVersion`
field when we patch the object so that the patch API
call will fail if there's a newer version of the object
in the system. We will eventually process the newer object

Also, replaced the objects we perform on from Job to Pod
to simplify the example.